### PR TITLE
ops/bug #25: experimental fix for nginx hangs on container startup.

### DIFF
--- a/files/nginx/dummy.conf
+++ b/files/nginx/dummy.conf
@@ -1,0 +1,8 @@
+server {
+  listen 9271;
+  location / {
+    add_header Content-Type text/plain;
+    return 200 'dummy server to ensure nginx starts up';
+  }
+}
+

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -21,6 +21,7 @@ COPY files/nginx/odk-setup.sh /scripts
 COPY files/local/customssl/*.pem /etc/customssl/live/local/
 
 COPY files/nginx/odk.conf.template /usr/share/nginx
+COPY files/nginx/dummy.conf /etc/nginx/conf.d/
 COPY --from=intermediate client/ /usr/share/nginx/html
 COPY --from=intermediate /tmp/version.txt /usr/share/nginx/html/
 


### PR DESCRIPTION
WIP, not ready

* as far as i can tell, this happens when auto_enable_configs comes up
  empty, and nginx tries to start with nothing enabled, and it causes
  unhappiness.
  * i'm not completely sure.
* this little workaround creates a dummy server (that isn't exposed
  outside of the container at all) that doesn't require SSL at all, and
  so it should always be enabled and start up.
* maybe it works, maybe it doesn't.