### PR TITLE
improve: apply http compression to downloaded csv files.

### DIFF
--- a/files/nginx/odk.conf.template
+++ b/files/nginx/odk.conf.template
@@ -19,7 +19,7 @@ server {
   gzip_vary on;
   gzip_min_length 1280;
   gzip_http_version 1.1;
-  gzip_types text/plain text/html text/css application/json application/x-javascript text/xml;
+  gzip_types text/plain text/html text/css application/json application/x-javascript text/xml text/csv;
 
   location ~ ^/v\d {
     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
* so large CSVs that are form attachments download compressed.

demonstration:

```
cxlt@durindana:forms$ http get https://odk.antinod.es/v1/forms/form/attachments/mydata.csv 'Authorization: Bearer <snip>' --verbose
GET /v1/forms/form/attachments/mydata.csv HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Authorization: Bearer <snip>
Connection: keep-alive
Host: odk.antinod.es
User-Agent: HTTPie/1.0.0



HTTP/1.1 200 OK
Connection: keep-alive
Content-Disposition: attachment; filename="mydata.csv"
Content-Encoding: gzip
Content-Type: text/csv; charset=utf-8
Date: Tue, 18 Dec 2018 02:09:48 GMT
ETag: W/"22014-2irQT/ZnnPrSDAfrpKkm14fQBXI"
Server: nginx
Strict-Transport-Security: max-age=31536000
Transfer-Encoding: chunked
Vary: Accept-Encoding
X-Content-Type-Options: nosniff
X-Powered-By: Express
```