### PR TITLE
bug #44: latest node:carbon has some sort of apt pinning problem.

### DIFF
--- a/service.dockerfile
+++ b/service.dockerfile
@@ -1,4 +1,4 @@
-FROM node:carbon
+FROM node:8.11.3
 
 WORKDIR /usr/odk
 


### PR DESCRIPTION
* so we lock onto 8.11.3 for now.