### PR TITLE
mail: use the base namshi/smtp image again now that it's up-to-date.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,7 @@ services:
       POSTGRES_PASSWORD: odk
       POSTGRES_DATABASE: odk
   mail:
-    build:
-      context: .
-      dockerfile: mail.dockerfile
+    image: "namshi/smtp:latest"
     volumes:
       - ./files/dkim/config:/etc/exim4/_docker_additional_macros:ro
       - ./files/dkim/rsa.private:/etc/exim4/domain.key:ro

--- a/mail.dockerfile
+++ b/mail.dockerfile
@@ -1,4 +1,0 @@
-FROM namshi/smtp
-
-RUN apt-get update && apt-get dist-upgrade -y
-


### PR DESCRIPTION
* we only layered on it to install security updates. now those are baked
  in upstream.