### PR TITLE
nginx: unzip uploads that were large enough to spool to disk.

### DIFF
--- a/files/nginx/inflate_body.lua
+++ b/files/nginx/inflate_body.lua
@@ -52,6 +52,12 @@ if content_encoding == "gzip" then
   ngx.req.read_body()
   local data = ngx.req.get_body_data()
 
+  if data == nil or data == '' then
+    local file = io.open(ngx.req.get_body_file(), "r")
+    data = file:read("*a")
+    file:close()
+  end
+
   if data ~= nil and data ~= '' then
     local new_data = inflate_body(data)
 


### PR DESCRIPTION
* there is a filesize threshold above which nginx will still accept the
  file, but it will spool it to disk rather than store it in memory.
* in this case, the lua interface changes and the file must be read.
* so we do that here.
* a lua expert should probably review this...