### PR TITLE
[work in progress] Remove the docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   build:
     machine:
       image: ubuntu-1604:201903-01
-      docker_layer_caching: true
 
     steps:
       - checkout


### PR DESCRIPTION
Removes the docker layer caching. It's preventing CircleCI from running because the ODK account doesn't support it.