### PR TITLE
Measure usage as proxy for number of deployments

### DIFF
--- a/docs/news.html
+++ b/docs/news.html
@@ -4,6 +4,14 @@
     <meta charset="utf-8">
     <title>ODK Central</title>
     <link rel="stylesheet" href="style.css">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-91951913-7"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-91951913-7');
+    </script>
   </head>
   <body>
     <div class="news-item">


### PR DESCRIPTION
Analytics code is what Google provided. The UA key is owned by the Open Data Kit account and @issa-tseng has read access.