### PR TITLE
bug #120: use newer nginx-certbot Docker image.

### DIFF
--- a/files/nginx/run_certbot.sh
+++ b/files/nginx/run_certbot.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Source in util.sh so we can have our nice tools
 . $(cd $(dirname $0); pwd)/util.sh

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -5,7 +5,7 @@ RUN files/prebuild/write-version.sh
 RUN files/prebuild/build-frontend.sh
 
 
-FROM staticfloat/nginx-certbot@sha256:a3fff8a1d75ae2b28d8e77d71468bc51bf98588c4762c6c7d7c55e0e548e6976
+FROM staticfloat/nginx-certbot@sha256:113300163d871119a261738964d7d8f24a478a605d56888a82e9f45fb353698d
 
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
this fixes #120, where the following error appears in the Docker logs when starting the nginx container:

> Error: urn:acme:error:unauthorized :: The client lacks sufficient authorization :: Account creation on ACMEv1 is disabled. Please upgrade your ACME client to a version that supports ACMEv2 / RFC 8555.

after updating staticfloat/nginx-certbot to fix that, a different error greets us:
```
nginx       | + parse_keyfiles /etc/nginx/conf.d/odk.conf.nokey
nginx       | + sed -n -e s&^\s*ssl_certificate_key\s*\(.*\);&\1&p /etc/nginx/conf.d/odk.conf.nokey
nginx       | /scripts/run_certbot.sh: 32: /scripts/run_certbot.sh: Bad substitution
```

using bash as the interpreter for `run_certbot.sh` makes this complaint go away. it looks like nginx-certbot is using bash for all its shell scripts now: https://github.com/staticfloat/docker-nginx-certbot/commit/507eac1b72875131d0efed442135eab388680bd6.